### PR TITLE
fix(theme): ensure logo state is applied when opening lyrics panel

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -2595,6 +2595,19 @@ function openLyricsPanel() {
     lyricsPanelOpen = true;
     storeLyricsOpen(true);
     document.body.classList.add("spotui-lyrics-panel");
+    
+    const logoVisible = storageGet("spotui:logo-visible");
+    if (logoVisible === "on") {
+        document.body.classList.add("logo-on");
+        document.body.classList.remove("logo-off");
+    } else if (logoVisible === "off") {
+        document.body.classList.add("logo-off");
+        document.body.classList.remove("logo-on");
+    } else {
+        document.body.classList.add("logo-on");
+        document.body.classList.remove("logo-off");
+    }
+    
     document.addEventListener("keydown", handleGlobalEsc);
     const root = document.getElementById("spotui-lyrics");
     if (root) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lyrics now consistently respect the saved logo visibility preference when opened.
  * The logo defaults to visible when no preference has been set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->