### PR TITLE
feat(theme): add play bar visibility toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Type `help` in the SpoTUI command bar to see a list of available commands.
 | `tui -ly -cp off` | Reset lyrics colors |
 | `tui -ly -animation <on/off>` | Toggle lyrics loader animation |
 | `tui -bar -bg <#hex> -border <#hex> -text <#hex>` | Set player bar colors |
+| `tui -bar -v <on/off>` | Toggle native play bar visibility |
+| `tui -bar -c <on/off>` | Toggle custom TUI play bar |
+| `tui -bar -c -progress <id>` | Set custom play bar progress style |
 | `tui -bar off` | Reset player bar colors |
 | `tui -progress -bg <#hex> -fg <#hex>` | Set progress bar colors |
 | `tui -progress off` | Reset progress bar colors |
@@ -103,6 +106,31 @@ Type `help` in the SpoTUI command bar to see a list of available commands.
 | `search`               | Open Spotify's native search   |
 | `theme`                | Browse and apply themes        |
 | `help`                 | Show the help panel            |
+
+## Custom Play Bar Progress Styles
+
+When the native Spotify play bar is hidden (`tui -bar -v off`), you can enable a custom, text-based TUI play bar (`tui -bar -c on`). This bar has a progress indicator with 13 different style presets.
+
+To set a progress style, use the command: `tui -bar -c -progress <id>`
+
+### Available Styles
+
+| ID | Preview Example | Description |
+|---|---|---|
+| `classic-block` | `████████░░░░░░░░` | Classic TUI block progress |
+| `dark-block` | `▓▓▓▓▓▓▓▓░░░░░░░░` | Dark block progress |
+| `gradient` | `██████▓▓▒▒░░░░░░` | Smooth block gradient |
+| `thin` | `━━━━━━━━░░░░░░░░` | Bold thin line with empty blocks |
+| `line` | `━━━━━━━━────────` | Smooth heavy and light line indicator |
+| `square` | `■■■■■■■■□□□□□□□□` | Square bullet style |
+| `circle` | `●●●●●●●●○○○○○○○○` | Circular bullet style |
+| `diamond` | `◆◆◆◆◆◆◆◆◇◇◇◇◇◇◇◇` | Diamond bullet style |
+| `chevron` | `>>>>>>>>░░░░░░░░` | Arrow / Chevron progress |
+| `triangle` | `▶▶▶▶▶▶▶▶▷▷▷▷▷▷▷▷` | Solid and empty play-button triangles |
+| `braille` | `⣿⣿⣿⣿⣿⣿⣿⣿⣀⣀⣀⣀⣀⣀⣀⣀` | Braille dot block progress |
+| `retro` | `▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱` | Retro segment blocks |
+| `pixel` | `█▀█▀█▀█▀░░░░░░░░` | Checkerboard pixel progress |
+| `dashed` | `━━━━━━━╸────────` | Dashed track with end handle |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Type `help` in the SpoTUI command bar to see a list of available commands.
 
 ## Custom Play Bar Progress Styles
 
-When the native Spotify play bar is hidden (`tui -bar -v off`), you can enable a custom, text-based TUI play bar (`tui -bar -c on`). This bar has a progress indicator with 13 different style presets.
+When the native Spotify play bar is hidden (`tui -bar -v off`), you can enable a custom, text-based TUI play bar (`tui -bar -c on`). This bar has a progress indicator with 14 different style presets.
 
 To set a progress style, use the command: `tui -bar -c -progress <id>`
 

--- a/theme.js
+++ b/theme.js
@@ -14,6 +14,8 @@ const PLAYER_BAR_BG = "spotui:player-bar-bg";
 const PLAYER_BAR_BORDER = "spotui:player-bar-border";
 const PLAYER_BAR_TEXT = "spotui:player-bar-text";
 const PLAYER_BAR_VISIBLE = "spotui:player-bar-visible";
+const CUSTOM_BAR_ENABLED = "spotui:custom-bar-enabled";
+const CUSTOM_BAR_PROGRESS_STYLE = "spotui:custom-bar-progress-style";
 const PROGRESS_BAR_BG = "spotui:progress-bar-bg";
 const PROGRESS_BAR_FG = "spotui:progress-bar-fg";
 const INPUT_BG = "spotui:input-bg";
@@ -721,6 +723,23 @@ body.spotui-tui-hidden #spotui-tui {
 			}
 `;
 
+const PROGRESS_STYLES = {
+    "classic-block": { fg: "█", bg: "░", width: 15 },
+    "dark-block": { fg: "▓", bg: "░", width: 15 },
+    "gradient": { fg: "█▓▒", bg: "░", width: 15 },
+    "thin": { fg: "━", bg: "░", width: 15 },
+    "line": { fg: "━", bg: "─", width: 15 },
+    "square": { fg: "■", bg: "□", width: 15 },
+    "circle": { fg: "●", bg: "○", width: 15 },
+    "diamond": { fg: "◆", bg: "◇", width: 15 },
+    "chevron": { fg: ">", bg: "░", width: 15 },
+    "triangle": { fg: "▶", bg: "▷", width: 15 },
+    "braille": { fg: "⣿", bg: "⣀", width: 15 },
+    "retro": { fg: "▰", bg: "▱", width: 15 },
+    "pixel": { fg: "█", bg: "▀", width: 15 },
+    "dashed": { fg: "━", bg: "╸", width: 15 }
+};
+
 const SPOTUI_ASCII_ART = [
     "   ▄████████    ▄███████▄  ▄██████▄      ███     ███    █▄   ▄█  ",
     "  ███    ███   ███    ███ ███    ███ ▀█████████▄ ███    ███ ███  ",
@@ -759,6 +778,8 @@ const COMMAND_LIST = [
     { cmd: "tui -ly -animation &lt;on/off&gt;", desc: "Toggle lyrics loader animation" },
     { cmd: "tui -bar -bg &lt;#hex&gt; -border &lt;#hex&gt; -text &lt;#hex&gt;", desc: "Set player bar colors" },
     { cmd: "tui -bar -v &lt;on/off&gt;", desc: "Toggle play bar visibility" },
+    { cmd: "tui -bar -c &lt;on/off&gt;", desc: "Toggle custom TUI play bar" },
+    { cmd: "tui -bar -c -progress &lt;id&gt;", desc: "Set custom bar progress style" },
     { cmd: "tui -bar off", desc: "Reset player bar colors" },
     { cmd: "tui -progress -bg &lt;#hex&gt; -fg &lt;#hex&gt;", desc: "Set progress bar colors" },
     { cmd: "tui -progress off", desc: "Reset progress bar colors" },
@@ -1429,6 +1450,138 @@ function applyPlayerBarVisibility() {
     }
 }
 
+function renderProgressBar(progress, styleId, width) {
+    const style = PROGRESS_STYLES[styleId] || PROGRESS_STYLES["classic-block"];
+    const filled = Math.round(progress * width);
+    const empty = width - filled;
+    let filledStr = "";
+    let emptyStr = "";
+    if (style.fg.length === 1) {
+        filledStr = style.fg.repeat(filled);
+        emptyStr = style.bg ? style.bg.repeat(empty) : "";
+    } else {
+        const fgChars = [...style.fg];
+        for (let i = 0; i < filled; i++) {
+            const idx = Math.floor((i / filled) * fgChars.length);
+            filledStr += fgChars[idx] || fgChars[fgChars.length - 1];
+        }
+        emptyStr = style.bg ? style.bg.repeat(empty) : "";
+    }
+    return filledStr + emptyStr;
+}
+
+function updateCustomBarWidth() {
+    const bar = document.getElementById("spotui-custom-bar");
+    if (!bar) return;
+    const progressEl = bar.querySelector(".spotui-custom-bar-progress");
+    if (!progressEl) return;
+    const rect = bar.getBoundingClientRect();
+    const availableWidth = rect.width - 400;
+    const width = Math.max(40, Math.floor(availableWidth / 16));
+    const progress = Spicetify.Player.getProgress();
+    const duration = Spicetify.Player.getDuration();
+    const progressPct = duration > 0 ? progress / duration : 0;
+    const styleId = storageGet(CUSTOM_BAR_PROGRESS_STYLE) || "classic-block";
+    progressEl.textContent = renderProgressBar(progressPct, styleId, width);
+}
+
+function drawCustomBarLeft(track, artist, liked) {
+    const left = document.createElement("div");
+    left.className = "spotui-custom-bar-left";
+    const heart = document.createElement("span");
+    heart.className = "spotui-custom-bar-heart";
+    heart.textContent = liked ? "♥" : "♡";
+    heart.addEventListener("click", async () => {
+        try { await Spicetify.Player.toggleHeart(); } catch (e) {}
+    });
+    const title = document.createElement("span");
+    title.className = "spotui-custom-bar-title";
+    title.textContent = track;
+    const artistSpan = document.createElement("span");
+    artistSpan.className = "spotui-custom-bar-artist";
+    artistSpan.textContent = artist;
+    left.appendChild(heart);
+    left.appendChild(title);
+    left.appendChild(artistSpan);
+    return left;
+}
+
+async function updateCustomBar() {
+    try {
+        const track = Spicetify.Player.data.item;
+        if (!track) return;
+        const progress = Spicetify.Player.getProgress();
+        const duration = Spicetify.Player.getDuration();
+        const volume = Spicetify.Player.getVolume();
+        const liked = Spicetify.Player.getHeart ? await Spicetify.Player.getHeart() : false;
+        const meta = track.metadata || {};
+        const title = track.name || meta.title || "Unknown";
+        const artist = track.artist || meta.artist_name || "Unknown";
+        const progressPct = duration > 0 ? progress / duration : 0;
+        const styleId = storageGet(CUSTOM_BAR_PROGRESS_STYLE) || "classic-block";
+        const bar = document.getElementById("spotui-custom-bar");
+        if (!bar) return;
+        const left = drawCustomBarLeft(title, artist, liked);
+        const progressEl = document.createElement("div");
+        progressEl.className = "spotui-custom-bar-progress";
+        const availableWidth = bar.getBoundingClientRect().width - 400;
+        const width = Math.max(40, Math.floor(availableWidth / 16));
+        progressEl.textContent = renderProgressBar(progressPct, styleId, width);
+        progressEl.addEventListener("click", (e) => {
+            const rect = progressEl.getBoundingClientRect();
+            const offsetX = e.clientX - rect.left;
+            const pct = Math.max(0, Math.min(1, offsetX / rect.width));
+            const seekMs = pct * duration;
+            try { Spicetify.Player.seek(seekMs); } catch (e) {}
+        });
+        const timeEl = document.createElement("div");
+        timeEl.className = "spotui-custom-bar-time";
+        timeEl.textContent = `${Math.floor(progress / 1000 / 60)}:${String(Math.floor(progress / 1000) % 60).padStart(2, "0")} / ${Math.floor(duration / 1000 / 60)}:${String(Math.floor(duration / 1000) % 60).padStart(2, "0")}`;
+        const volEl = document.createElement("div");
+        volEl.className = "spotui-custom-bar-vol";
+        volEl.textContent = `Vol: ${Math.round(volume * 100)}%`;
+        const right = document.createElement("div");
+        right.className = "spotui-custom-bar-right";
+        right.appendChild(volEl);
+        const center = document.createElement("div");
+        center.className = "spotui-custom-bar-center";
+        center.appendChild(progressEl);
+        center.appendChild(timeEl);
+        bar.innerHTML = "";
+        bar.appendChild(left);
+        bar.appendChild(center);
+        bar.appendChild(right);
+    } catch (e) {
+        console.error("SpoTUI: Failed to update custom bar", e);
+    }
+}
+
+function applyCustomBarState() {
+    const enabled = storageGet(CUSTOM_BAR_ENABLED);
+    const visible = storageGet(PLAYER_BAR_VISIBLE);
+    if (enabled === "on" && visible === "off") {
+        document.body.classList.add("spotui-custom-bar-on");
+        let bar = document.getElementById("spotui-custom-bar");
+        if (!bar) {
+            bar = document.createElement("div");
+            bar.id = "spotui-custom-bar";
+            bar.className = "spotui-custom-bar";
+            document.body.appendChild(bar);
+        }
+        updateCustomBar();
+        const interval = setInterval(updateCustomBar, 300);
+        window.spotuiCustomBarInterval = interval;
+        window.addEventListener("resize", updateCustomBarWidth);
+    } else {
+        document.body.classList.remove("spotui-custom-bar-on");
+        if (window.spotuiCustomBarInterval) {
+            clearInterval(window.spotuiCustomBarInterval);
+            delete window.spotuiCustomBarInterval;
+        }
+        window.removeEventListener("resize", updateCustomBarWidth);
+    }
+}
+
 function applyProgressBarColors() {
     try {
         applyCssVar(PROGRESS_BAR_BG, "--progress-bar-background");
@@ -2039,6 +2192,21 @@ async function execute(cmd, opts = {}) {
                         "-text": PLAYER_BAR_TEXT,
                     });
                     applyPlayerBarColors();
+                }
+            } else if (args.includes("-c")) {
+                const idx = args.indexOf("-c");
+                const state = args[idx + 1];
+                if (state === "on" || state === "off") {
+                    storageSet(CUSTOM_BAR_ENABLED, state);
+                    applyCustomBarState();
+                }
+                if (args.includes("-progress")) {
+                    const pIdx = args.indexOf("-progress");
+                    const styleId = args[pIdx + 1];
+                    if (styleId && PROGRESS_STYLES[styleId]) {
+                        storageSet(CUSTOM_BAR_PROGRESS_STYLE, styleId);
+                        if (storageGet(CUSTOM_BAR_ENABLED) === "on") updateCustomBar();
+                    }
                 }
             } else {
                 handleColorArgs(args, {
@@ -2855,8 +3023,11 @@ function resetAllSettings() {
     storageRemove(PLAYER_BAR_BORDER);
     storageRemove(PLAYER_BAR_TEXT);
     storageRemove(PLAYER_BAR_VISIBLE);
+    storageRemove(CUSTOM_BAR_ENABLED);
+    storageRemove(CUSTOM_BAR_PROGRESS_STYLE);
     applyPlayerBarColors();
     applyPlayerBarVisibility();
+    applyCustomBarState();
 
     storageRemove(PROGRESS_BAR_BG);
     storageRemove(PROGRESS_BAR_FG);
@@ -2907,6 +3078,7 @@ try {
     applyLyricColors();
     applyPlayerBarColors();
     applyPlayerBarVisibility();
+    applyCustomBarState();
     applyProgressBarColors();
     applyInputColors();
 } catch { }

--- a/theme.js
+++ b/theme.js
@@ -13,6 +13,7 @@ const LYRICS_COLOR_LIGHT_INACTIVE = "spotui:lyrics-color-light-inactive";
 const PLAYER_BAR_BG = "spotui:player-bar-bg";
 const PLAYER_BAR_BORDER = "spotui:player-bar-border";
 const PLAYER_BAR_TEXT = "spotui:player-bar-text";
+const PLAYER_BAR_VISIBLE = "spotui:player-bar-visible";
 const PROGRESS_BAR_BG = "spotui:progress-bar-bg";
 const PROGRESS_BAR_FG = "spotui:progress-bar-fg";
 const INPUT_BG = "spotui:input-bg";
@@ -714,6 +715,10 @@ body.spotui-tui-hidden #spotui-tui {
 			body:not(.spotui-tui-hidden) header {
 			    display: none !important;
 			}
+
+			body.spotui-bar-off #spotui-tui {
+			    bottom: 0 !important;
+			}
 `;
 
 const SPOTUI_ASCII_ART = [
@@ -753,6 +758,7 @@ const COMMAND_LIST = [
     { cmd: "tui -ly -cp off", desc: "Reset lyrics colors" },
     { cmd: "tui -ly -animation &lt;on/off&gt;", desc: "Toggle lyrics loader animation" },
     { cmd: "tui -bar -bg &lt;#hex&gt; -border &lt;#hex&gt; -text &lt;#hex&gt;", desc: "Set player bar colors" },
+    { cmd: "tui -bar -v &lt;on/off&gt;", desc: "Toggle play bar visibility" },
     { cmd: "tui -bar off", desc: "Reset player bar colors" },
     { cmd: "tui -progress -bg &lt;#hex&gt; -fg &lt;#hex&gt;", desc: "Set progress bar colors" },
     { cmd: "tui -progress off", desc: "Reset progress bar colors" },
@@ -1410,6 +1416,19 @@ function applyPlayerBarColors() {
     }
 }
 
+function applyPlayerBarVisibility() {
+    try {
+        const visible = storageGet(PLAYER_BAR_VISIBLE);
+        if (visible === "off") {
+            document.body.classList.add("spotui-bar-off");
+        } else {
+            document.body.classList.remove("spotui-bar-off");
+        }
+    } catch (e) {
+        console.error("SpoTUI: Failed to apply player bar visibility", e);
+    }
+}
+
 function applyProgressBarColors() {
     try {
         applyCssVar(PROGRESS_BAR_BG, "--progress-bar-background");
@@ -2005,12 +2024,30 @@ async function execute(cmd, opts = {}) {
             return;
         }
         if (args.includes("-bar")) {
-            handleColorArgs(args, {
-                "-bg": PLAYER_BAR_BG,
-                "-border": PLAYER_BAR_BORDER,
-                "-text": PLAYER_BAR_TEXT,
-            });
-            applyPlayerBarColors();
+            if (args.includes("-v")) {
+                const idx = args.indexOf("-v");
+                const state = args[idx + 1];
+                if (state === "on" || state === "off") {
+                    storageSet(PLAYER_BAR_VISIBLE, state);
+                    applyPlayerBarVisibility();
+                }
+                const newArgs = args.filter((arg, i) => i !== idx && i !== idx + 1);
+                if (newArgs.length > 1) {
+                    handleColorArgs(newArgs, {
+                        "-bg": PLAYER_BAR_BG,
+                        "-border": PLAYER_BAR_BORDER,
+                        "-text": PLAYER_BAR_TEXT,
+                    });
+                    applyPlayerBarColors();
+                }
+            } else {
+                handleColorArgs(args, {
+                    "-bg": PLAYER_BAR_BG,
+                    "-border": PLAYER_BAR_BORDER,
+                    "-text": PLAYER_BAR_TEXT,
+                });
+                applyPlayerBarColors();
+            }
             return;
         }
         if (args.includes("-progress")) {
@@ -2817,7 +2854,9 @@ function resetAllSettings() {
     storageRemove(PLAYER_BAR_BG);
     storageRemove(PLAYER_BAR_BORDER);
     storageRemove(PLAYER_BAR_TEXT);
+    storageRemove(PLAYER_BAR_VISIBLE);
     applyPlayerBarColors();
+    applyPlayerBarVisibility();
 
     storageRemove(PROGRESS_BAR_BG);
     storageRemove(PROGRESS_BAR_FG);
@@ -2867,6 +2906,7 @@ try {
     }
     applyLyricColors();
     applyPlayerBarColors();
+    applyPlayerBarVisibility();
     applyProgressBarColors();
     applyInputColors();
 } catch { }

--- a/theme.js
+++ b/theme.js
@@ -1491,7 +1491,7 @@ function drawCustomBarLeft(track, artist, liked) {
     left.className = "spotui-custom-bar-left";
     const heart = document.createElement("button");
     heart.className = "spotui-custom-bar-heart";
-    heart.textContent = liked ? "♥" : "♡";
+    heart.textContent = liked ? "X" : "♥";
     heart.setAttribute("aria-label", liked ? "Unlike track" : "Like track");
     heart.addEventListener("click", async () => {
         try { await Spicetify.Player.toggleHeart(); } catch {}

--- a/theme.js
+++ b/theme.js
@@ -1489,11 +1489,18 @@ function updateCustomBarWidth() {
 function drawCustomBarLeft(track, artist, liked) {
     const left = document.createElement("div");
     left.className = "spotui-custom-bar-left";
-    const heart = document.createElement("span");
+    const heart = document.createElement("button");
     heart.className = "spotui-custom-bar-heart";
     heart.textContent = liked ? "♥" : "♡";
+    heart.setAttribute("aria-label", liked ? "Unlike track" : "Like track");
     heart.addEventListener("click", async () => {
-        try { await Spicetify.Player.toggleHeart(); } catch (e) {}
+        try { await Spicetify.Player.toggleHeart(); } catch {}
+    });
+    heart.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            try { Spicetify.Player.toggleHeart(); } catch {}
+        }
     });
     const title = document.createElement("span");
     title.className = "spotui-custom-bar-title";
@@ -1510,7 +1517,10 @@ function drawCustomBarLeft(track, artist, liked) {
 async function updateCustomBar() {
     try {
         const track = Spicetify.Player.data.item;
-        if (!track) return;
+        if (!track) {
+            bar.innerHTML = "<div class='spotui-custom-bar-empty'>Nothing playing</div>";
+            return;
+        }
         const progress = Spicetify.Player.getProgress();
         const duration = Spicetify.Player.getDuration();
         const volume = Spicetify.Player.getVolume();
@@ -1523,8 +1533,9 @@ async function updateCustomBar() {
         const bar = document.getElementById("spotui-custom-bar");
         if (!bar) return;
         const left = drawCustomBarLeft(title, artist, liked);
-        const progressEl = document.createElement("div");
+        const progressEl = document.createElement("button");
         progressEl.className = "spotui-custom-bar-progress";
+        progressEl.setAttribute("aria-label", "Playback progress");
         const availableWidth = bar.getBoundingClientRect().width - 400;
         const width = Math.max(40, Math.floor(availableWidth / 16));
         progressEl.textContent = renderProgressBar(progressPct, styleId, width);
@@ -1533,7 +1544,15 @@ async function updateCustomBar() {
             const offsetX = e.clientX - rect.left;
             const pct = Math.max(0, Math.min(1, offsetX / rect.width));
             const seekMs = pct * duration;
-            try { Spicetify.Player.seek(seekMs); } catch (e) {}
+            try { Spicetify.Player.seek(seekMs); } catch {}
+        });
+        progressEl.addEventListener("keydown", (e) => {
+            if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+                e.preventDefault();
+                const step = (e.key === "ArrowLeft" ? -5000 : 5000);
+                const targetMs = Math.max(0, Math.min(duration, progress + step));
+                try { Spicetify.Player.seek(targetMs); } catch {}
+            }
         });
         const timeEl = document.createElement("div");
         timeEl.className = "spotui-custom-bar-time";
@@ -1558,7 +1577,6 @@ async function updateCustomBar() {
 }
 
 function applyCustomBarState() {
-    // Clear any existing interval before changing state
     if (window.spotuiCustomBarInterval) {
         clearInterval(window.spotuiCustomBarInterval);
         delete window.spotuiCustomBarInterval;
@@ -2190,7 +2208,7 @@ async function execute(cmd, opts = {}) {
                 if (state === "on" || state === "off") {
                     storageSet(PLAYER_BAR_VISIBLE, state);
                     applyPlayerBarVisibility();
-                    applyCustomBarState(); // Reapply custom bar state after visibility change
+                    applyCustomBarState();
                 }
                 const newArgs = args.filter((arg, i) => i !== idx && i !== idx + 1);
                 if (newArgs.length > 1) {

--- a/theme.js
+++ b/theme.js
@@ -724,20 +724,20 @@ body.spotui-tui-hidden #spotui-tui {
 `;
 
 const PROGRESS_STYLES = {
-    "classic-block": { fg: "█", bg: "░", width: 15 },
-    "dark-block": { fg: "▓", bg: "░", width: 15 },
-    "gradient": { fg: "█▓▒", bg: "░", width: 15 },
-    "thin": { fg: "━", bg: "░", width: 15 },
-    "line": { fg: "━", bg: "─", width: 15 },
-    "square": { fg: "■", bg: "□", width: 15 },
-    "circle": { fg: "●", bg: "○", width: 15 },
-    "diamond": { fg: "◆", bg: "◇", width: 15 },
-    "chevron": { fg: ">", bg: "░", width: 15 },
-    "triangle": { fg: "▶", bg: "▷", width: 15 },
-    "braille": { fg: "⣿", bg: "⣀", width: 15 },
-    "retro": { fg: "▰", bg: "▱", width: 15 },
-    "pixel": { fg: "█", bg: "▀", width: 15 },
-    "dashed": { fg: "━", bg: "╸", width: 15 }
+    "classic-block": { fg: "█", bg: "░" },
+    "dark-block": { fg: "▓", bg: "░" },
+    "gradient": { fg: "█▓▒", bg: "░" },
+    "thin": { fg: "━", bg: "░" },
+    "line": { fg: "━", bg: "─" },
+    "square": { fg: "■", bg: "□" },
+    "circle": { fg: "●", bg: "○" },
+    "diamond": { fg: "◆", bg: "◇" },
+    "chevron": { fg: ">", bg: "░" },
+    "triangle": { fg: "▶", bg: "▷" },
+    "braille": { fg: "⣿", bg: "⣀" },
+    "retro": { fg: "▰", bg: "▱" },
+    "pixel": { fg: "█", bg: "▀" },
+    "dashed": { fg: "━", bg: "╸" }
 };
 
 const SPOTUI_ASCII_ART = [
@@ -1445,8 +1445,8 @@ function applyPlayerBarVisibility() {
         } else {
             document.body.classList.remove("spotui-bar-off");
         }
-    } catch (e) {
-        console.error("SpoTUI: Failed to apply player bar visibility", e);
+    } catch {
+        console.error("SpoTUI: Failed to apply player bar visibility");
     }
 }
 
@@ -1471,6 +1471,7 @@ function renderProgressBar(progress, styleId, width) {
 }
 
 function updateCustomBarWidth() {
+    if (!document.body.classList.contains("spotui-custom-bar-on")) return;
     const bar = document.getElementById("spotui-custom-bar");
     if (!bar) return;
     const progressEl = bar.querySelector(".spotui-custom-bar-progress");
@@ -1551,12 +1552,18 @@ async function updateCustomBar() {
         bar.appendChild(left);
         bar.appendChild(center);
         bar.appendChild(right);
-    } catch (e) {
-        console.error("SpoTUI: Failed to update custom bar", e);
+    } catch {
+        console.error("SpoTUI: Failed to update custom bar");
     }
 }
 
 function applyCustomBarState() {
+    // Clear any existing interval before changing state
+    if (window.spotuiCustomBarInterval) {
+        clearInterval(window.spotuiCustomBarInterval);
+        delete window.spotuiCustomBarInterval;
+    }
+
     const enabled = storageGet(CUSTOM_BAR_ENABLED);
     const visible = storageGet(PLAYER_BAR_VISIBLE);
     if (enabled === "on" && visible === "off") {
@@ -2183,6 +2190,7 @@ async function execute(cmd, opts = {}) {
                 if (state === "on" || state === "off") {
                     storageSet(PLAYER_BAR_VISIBLE, state);
                     applyPlayerBarVisibility();
+                    applyCustomBarState(); // Reapply custom bar state after visibility change
                 }
                 const newArgs = args.filter((arg, i) => i !== idx && i !== idx + 1);
                 if (newArgs.length > 1) {

--- a/user.css
+++ b/user.css
@@ -690,3 +690,84 @@ body.spotui-search-mode .Root__globalNav .main-globalNav-browseButtonWrapper {
 body.spotui-bar-off .Root__now-playing-bar {
     display: none !important;
 }
+
+body.spotui-custom-bar-on #spotui-tui {
+    bottom: 3.5rem !important;
+}
+
+#spotui-custom-bar {
+    display: none;
+    position: fixed;
+    left: 0; right: 0; bottom: 0;
+    height: 3.5rem;
+    background: var(--player-bar-background, #000);
+    border-top: 1px solid var(--spotui-accent, #ff8c42);
+    color: #ddd;
+    font-family: "JetBrains Mono", "Fira Code", monospace;
+    font-size: 14px;
+    padding: 0 16px;
+    box-sizing: border-box;
+    z-index: 9998;
+    align-items: center;
+    justify-content: space-between;
+}
+
+body.spotui-custom-bar-on #spotui-custom-bar {
+    display: flex;
+}
+
+.spotui-custom-bar-center {
+    display: flex;
+    align-items: center;
+    gap: 24px;
+}
+
+.spotui-custom-bar-right {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.spotui-custom-bar-left {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-width: 0;
+}
+
+.spotui-custom-bar-heart {
+    cursor: pointer;
+    color: var(--spotui-accent, #ff8c42);
+}
+
+.spotui-custom-bar-title {
+    color: var(--spotui-accent, #ff8c42);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.spotui-custom-bar-artist {
+    color: #b3b3b3;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.spotui-custom-bar-progress {
+    color: var(--spotui-accent, #ff8c42);
+    font-family: monospace;
+    letter-spacing: 0;
+    cursor: pointer;
+    user-select: none;
+}
+
+.spotui-custom-bar-time {
+    color: #b3b3b3;
+    font-variant-numeric: tabular-nums;
+}
+
+.spotui-custom-bar-vol {
+    color: #b3b3b3;
+    font-variant-numeric: tabular-nums;
+}

--- a/user.css
+++ b/user.css
@@ -702,7 +702,7 @@ body.spotui-custom-bar-on #spotui-tui {
     height: 3.5rem;
     background: var(--player-bar-background, #000);
     border-top: 1px solid var(--spotui-accent, #ff8c42);
-    color: #ddd;
+    color: var(--player-bar-text-color, #ddd);
     font-family: "JetBrains Mono", "Fira Code", monospace;
     font-size: 14px;
     padding: 0 16px;
@@ -748,7 +748,7 @@ body.spotui-custom-bar-on #spotui-custom-bar {
 }
 
 .spotui-custom-bar-artist {
-    color: #b3b3b3;
+    color: var(--player-bar-text-color, #b3b3b3);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -763,11 +763,11 @@ body.spotui-custom-bar-on #spotui-custom-bar {
 }
 
 .spotui-custom-bar-time {
-    color: #b3b3b3;
+    color: var(--player-bar-text-color, #b3b3b3);
     font-variant-numeric: tabular-nums;
 }
 
 .spotui-custom-bar-vol {
-    color: #b3b3b3;
+    color: var(--player-bar-text-color, #b3b3b3);
     font-variant-numeric: tabular-nums;
 }

--- a/user.css
+++ b/user.css
@@ -701,6 +701,9 @@ body.spotui-custom-bar-on #spotui-tui {
     left: 0; right: 0; bottom: 0;
     height: 3.5rem;
     background: var(--player-bar-background, #000);
+    border: none;
+    box-shadow: none;
+    color: var(--player-bar-text-color, #ddd);
     border-top: 1px solid var(--spotui-accent, #ff8c42);
     color: var(--player-bar-text-color, #ddd);
     font-family: "JetBrains Mono", "Fira Code", monospace;
@@ -737,11 +740,19 @@ body.spotui-custom-bar-on #spotui-custom-bar {
 
 .spotui-custom-bar-heart {
     cursor: pointer;
+    appearance: none;
+    -webkit-appearance: none;
+    border: none;
+    background: none;
+    box-shadow: none;
+    outline: none;
     color: var(--spotui-accent, #ff8c42);
+    background: transparent;
 }
 
 .spotui-custom-bar-title {
     color: var(--spotui-accent, #ff8c42);
+    background: transparent;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -756,9 +767,16 @@ body.spotui-custom-bar-on #spotui-custom-bar {
 
 .spotui-custom-bar-progress {
     color: var(--spotui-accent, #ff8c42);
+    background: transparent;
     font-family: monospace;
     letter-spacing: 0;
     cursor: pointer;
+    appearance: none;
+    -webkit-appearance: none;
+    border: none;
+    background: none;
+    box-shadow: none;
+    outline: none;
     user-select: none;
 }
 

--- a/user.css
+++ b/user.css
@@ -686,3 +686,7 @@ body.spotui-search-mode .Root__globalNav button[aria-label="Home"],
 body.spotui-search-mode .Root__globalNav .main-globalNav-browseButtonWrapper {
     display: none !important;
 }
+
+body.spotui-bar-off .Root__now-playing-bar {
+    display: none !important;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable custom player bar with track details, like status, playback progress, elapsed and total time, and volume controls.
  * Supports keyboard-accessible liking and seeking, periodic playback updates, responsive sizing, configurable colors, and 14 progress-display styles.
  * Displays “Nothing playing” when no track is active and uses clear liked/unliked indicators.
  * Added controls to show or hide the custom and native player bars.
* **Bug Fixes**
  * Custom player-bar settings now persist across restarts, reset correctly, and update when bar visibility changes.
* **Documentation**
  * Documented player-bar commands and available progress styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->