### PR TITLE
fix(theme): fix banner overlap

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -726,7 +726,7 @@ body.spotui-tui-hidden #spotui-tui {
 
 #spotui-update-banner {
     position: fixed;
-    top: 20px;
+    top: 70px;
     right: 20px;
     background: #000;
     color: #ddd;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Moved the update banner lower on the page, from 20px to 70px below the top of the viewport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->