### PR TITLE
fix(theme): fix lyrics not loading on Spotify boot

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -3146,6 +3146,18 @@ function storeLyricsOpen(open) {
     storageSet(LYRICS_STORAGE_KEY, open ? "1" : "0");
 }
 
+function waitForPlayerReadyThen(callback, attempt = 0) {
+    if (Spicetify?.Player?.data?.item) {
+        callback();
+        return;
+    }
+    if (attempt >= 40) {
+        callback();
+        return;
+    }
+    setTimeout(() => waitForPlayerReadyThen(callback, attempt + 1), 250);
+}
+
 function openLyricsPanel() {
     closeActivePanel();
     lyricsPanelOpen = true;
@@ -3335,7 +3347,7 @@ setTimeout(() => { launchFirstBootIfNeeded().catch(() => {}); }, 2000);
 
 try {
     if (storageGet(LYRICS_STORAGE_KEY) === "1") {
-        setTimeout(() => openLyricsPanel(), 2000);
+        waitForPlayerReadyThen(() => openLyricsPanel());
     }
     if (storageGet(WP_URL_KEY)) {
         setTimeout(() => setWallpaper(storageGet(WP_URL_KEY), storageGet(WP_OPACITY_KEY) || "1", false), 1500);

--- a/theme.js
+++ b/theme.js
@@ -3362,7 +3362,9 @@ setTimeout(() => { launchFirstBootIfNeeded().catch(() => {}); }, 2000);
 
 try {
     if (storageGet(LYRICS_STORAGE_KEY) === "1") {
-        waitForPlayerReadyThen(() => openLyricsPanel());
+        waitForPlayerReadyThen(() => {
+            if (storageGet(LYRICS_STORAGE_KEY) === "1") openLyricsPanel();
+        });
     }
     if (storageGet(WP_URL_KEY)) {
         setTimeout(() => setWallpaper(storageGet(WP_URL_KEY), storageGet(WP_OPACITY_KEY) || "1", false), 1500);

--- a/theme.js
+++ b/theme.js
@@ -3146,16 +3146,31 @@ function storeLyricsOpen(open) {
     storageSet(LYRICS_STORAGE_KEY, open ? "1" : "0");
 }
 
+function hasPlayableTrackItem() {
+    const item = Spicetify?.Player?.data?.item;
+    return Boolean(item?.uri && String(item.uri).includes(":track:"));
+}
+
 function waitForPlayerReadyThen(callback, attempt = 0) {
-    if (Spicetify?.Player?.data?.item) {
+    if (hasPlayableTrackItem()) {
         callback();
         return;
     }
     if (attempt >= 40) {
         callback();
+        pollForTrackThenReload();
         return;
     }
     setTimeout(() => waitForPlayerReadyThen(callback, attempt + 1), 250);
+}
+
+function pollForTrackThenReload() {
+    if (!lyricsPanelOpen) return;
+    if (hasPlayableTrackItem()) {
+        loadLyricsForCurrentTrack();
+        return;
+    }
+    setTimeout(pollForTrackThenReload, 1000);
 }
 
 function openLyricsPanel() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lyrics restoration when track information is temporarily unavailable.
  * Lyrics now verify that a playable track is available before proceeding.
  * If the track is not ready after the initial wait, lyrics continue checking in the background and reload automatically when playback becomes available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->