### PR TITLE
feat(panels): add loader to themes pane

### DIFF
--- a/src/panels.js
+++ b/src/panels.js
@@ -133,7 +133,7 @@ export async function openThemePanel() {
     const panel = document.getElementById("spotui-theme-panel");
     if (!panel) return;
 
-    panel.innerHTML = "<p>Loading themes...</p>";
+    panel.innerHTML = `<div class="spotui-theme-loading"><div class="spotui-lyrics-loader active"></div></div>`;
 
     loadThemeFeed(
         () => {

--- a/src/styles.js
+++ b/src/styles.js
@@ -532,6 +532,20 @@ body.spotui-theme-panel #spotui-theme-panel {
     display: flex;
 }
 
+.spotui-theme-loading {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex: 1;
+    min-height: 0;
+    height: 100%;
+}
+
+#spotui-theme-panel .spotui-lyrics-loader {
+    display: block !important;
+    animation: spotui-loader-anim 0.8s infinite linear;
+}
+
 .theme-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Improved the theme panel’s loading state with a centered, animated spinner.
  * The spinner now remains visible while themes are loading, providing clearer visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->