### PR TITLE
feat(theme): add exit tilte to help pane

### DIFF
--- a/src/panels.js
+++ b/src/panels.js
@@ -68,9 +68,12 @@ export function openHelpPanel() {
     setPanelState("spotui-help-panel", "spotui-help-panel", "helpPanelOpen", true);
     const panel = document.getElementById("spotui-help-panel");
     if (panel) {
-        panel.innerHTML = COMMAND_LIST.map(
-            item => `<div class="help-item"><span class="command">${item.cmd}</span><span class="description">${item.desc}</span></div>`
-        ).join('');
+        const content = panel.querySelector('.spotui-help-content');
+        if (content) {
+            content.innerHTML = COMMAND_LIST.map(
+                item => `<div class="help-item"><span class="command">${item.cmd}</span><span class="description">${item.desc}</span></div>`
+            ).join('');
+        }
     }
 }
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -526,10 +526,33 @@ body.spotui-playlist-panel #spotui-playlist-panel {
     background: var(--panel-bg-color, transparent);
 }
 
+#spotui-help-panel {
+    border: none;
+    padding: 0;
+    margin: 33vh 5vw 8px;
+}
+
+.spotui-help-fieldset {
+    border: 1px solid var(--panel-border-color, rgba(255, 140, 66, 0.3));
+    border-radius: 6px;
+    padding: 30px;
+    height: 100%;
+    overflow-y: auto;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    background: var(--panel-bg-color, transparent);
+}
+
 body.spotui-help-panel #spotui-help-panel,
 body.spotui-about-panel #spotui-about-panel,
 body.spotui-theme-panel #spotui-theme-panel {
     display: flex;
+}
+
+.spotui-help-legend {
+    float: right;
+    color: var(--panel-text-color, #ff8c42);
+    padding: 0 5px;
 }
 
 .spotui-theme-loading {

--- a/src/terminal.js
+++ b/src/terminal.js
@@ -29,7 +29,7 @@ export function createTerminal() {
         <legend>Songs</legend>
     </fieldset>
 </div>
-<div id="spotui-help-panel" hidden></div>
+<div id="spotui-help-panel" hidden><fieldset class="spotui-help-fieldset"><legend class="spotui-help-legend">Exit - Esc</legend><div class="spotui-help-content"></div></fieldset></div>
 <div id="spotui-about-panel" hidden></div>
 <div id="spotui-theme-panel" hidden></div>
 <div id="spotui-onboarding-panel" hidden></div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated the help panel with a clearer fieldset layout and an “Exit - Esc” label.
  - Improved help content styling with a bordered, scrollable display.
  - Help commands now render within the designated content area without disrupting the surrounding panel structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->